### PR TITLE
Add correlation ID propagation

### DIFF
--- a/features/execution/api_routes.py
+++ b/features/execution/api_routes.py
@@ -67,6 +67,8 @@ def execute_market_order():
             
         # Get execution service
         execution_service = get_execution_service()
+        from uuid import uuid4
+        correlation_id = data.get('correlation_id') or str(uuid4())
         
         # Check position risk if provided
         price = data.get('price')
@@ -90,7 +92,7 @@ def execute_market_order():
         )
                 
         # Execute order
-        order = execution_service.execute_market_order(order_request)
+        order = execution_service.execute_market_order(order_request, correlation_id=correlation_id)
         
         if not order:
             return jsonify({

--- a/features/execution/service.py
+++ b/features/execution/service.py
@@ -151,7 +151,7 @@ class ExecutionService:
                 reason=f"Risk check failed: {str(e)}"
             )
     
-    def execute_market_order(self, order_request: OrderRequest) -> Optional[OrderResult]:
+    def execute_market_order(self, order_request: OrderRequest, correlation_id: Optional[str] = None) -> Optional[OrderResult]:
         """
         Execute a market order.
         
@@ -204,7 +204,8 @@ class ExecutionService:
                     'timestamp': result.created_at.isoformat()
                 },
                 channel='execution:orders',
-                source='execution_service'
+                source='execution_service',
+                correlation_id=correlation_id
             )
             
             return result
@@ -213,7 +214,7 @@ class ExecutionService:
             logger.error(f"Error executing market order for {order_request.symbol}: {e}")
             return None
     
-    def execute_limit_order(self, order_request: OrderRequest) -> Optional[OrderResult]:
+    def execute_limit_order(self, order_request: OrderRequest, correlation_id: Optional[str] = None) -> Optional[OrderResult]:
         """
         Execute a limit order.
         
@@ -273,7 +274,8 @@ class ExecutionService:
                     'timestamp': result.created_at.isoformat()
                 },
                 channel='execution:orders',
-                source='execution_service'
+                source='execution_service',
+                correlation_id=correlation_id
             )
             
             return result
@@ -282,7 +284,7 @@ class ExecutionService:
             logger.error(f"Error executing limit order for {order_request.symbol}: {e}")
             return None
     
-    def cancel_order(self, order_id: str) -> bool:
+    def cancel_order(self, order_id: str, correlation_id: Optional[str] = None) -> bool:
         """
         Cancel an open order.
         
@@ -304,7 +306,8 @@ class ExecutionService:
                         'timestamp': datetime.now().isoformat()
                     },
                     channel='execution:orders',
-                    source='execution_service'
+                    source='execution_service',
+                    correlation_id=correlation_id
                 )
             
             return success


### PR DESCRIPTION
## Summary
- attach correlation ids to payloads in `publish_event_async` and `publish_event`
- include correlation ids when ingesting messages
- forward correlation ids from ingestion to parsing events
- accept optional correlation ids in execution service and API routes

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pytz')*

------
https://chatgpt.com/codex/tasks/task_e_6866d6a6faa083229d1af0874e4b9f31