### PR TITLE
Add message export feature

### DIFF
--- a/features/blueprint_registry.py
+++ b/features/blueprint_registry.py
@@ -16,12 +16,14 @@ BLUEPRINT_REGISTRY = [
     ("alpaca", "features.alpaca.api", "alpaca_bp"),
     ("parsing_api", "features.parsing.api", "parsing_api_bp"),
     ("setups", "features.setups.api", "setups_bp"),
+    ("export_api", "features.export.api", "export_bp"),
     
     # Dashboard Blueprints
     ("parsing_dashboard", "features.parsing.dashboard", "parsing_dashboard_bp"),
     ("discord_dashboard", "features.discord_bot.dashboard", "discord_bp"),
     ("channels_dashboard", "features.discord_channels.dashboard", "channels_bp"),
     ("ingestion_dashboard", "features.ingestion.dashboard", "ingest_bp"),
+    ("export_dashboard", "features.export.dashboard", "export_dashboard_bp"),
 ]
 
 # Additional blueprints that require special handling

--- a/features/dashboard/templates/dashboard/status.html
+++ b/features/dashboard/templates/dashboard/status.html
@@ -379,6 +379,9 @@
                             <button class="btn btn-sm btn-outline-primary" onclick="refreshEvents()">
                                 <i class="fas fa-sync-alt"></i> Refresh
                             </button>
+                            <a href="/dashboard/export/" class="btn btn-sm btn-outline-success ms-2" title="Export messages">
+                                <i class="fas fa-download"></i> Export
+                            </a>
                         </div>
                     </div>
                     <div class="card-body">

--- a/features/export/README.md
+++ b/features/export/README.md
@@ -1,0 +1,24 @@
+# Export Feature
+
+The export feature allows administrators to download ingested Discord messages as
+JSON for compliance or backup purposes. Messages can be filtered by channel,
+author, and date range. A small CLI tool is provided for offline exports.
+
+## API
+`GET /api/export/messages`
+Query parameters:
+- `channel`: filter by channel ID
+- `author`: filter by author ID
+- `start`: start datetime (ISO format)
+- `end`: end datetime (ISO format)
+- `limit`: maximum number of messages (default 1000)
+
+The endpoint returns a downloadable JSON file. To receive raw JSON without the
+download header, use `/api/export/messages.json`.
+
+## Dashboard
+An "Export" button was added to the system status dashboard. It links to a
+simple form at `/dashboard/export` where exports can be initiated.
+
+## CLI
+Run `python -m features.export.cli --help` for command usage.

--- a/features/export/__init__.py
+++ b/features/export/__init__.py
@@ -1,0 +1,1 @@
+"""Export feature package."""

--- a/features/export/api.py
+++ b/features/export/api.py
@@ -1,0 +1,67 @@
+"""Export API Blueprint
+
+Provides endpoints for downloading ingested Discord messages as JSON
+filtered by channel, author, and date range.
+"""
+import io
+import json
+import logging
+from datetime import datetime
+from flask import Blueprint, request, send_file, jsonify
+
+from .service import get_messages
+
+logger = logging.getLogger(__name__)
+
+export_bp = Blueprint('export_api', __name__, url_prefix='/api/export')
+
+
+def parse_date(value: str) -> datetime | None:
+    """Parse ISO date string to datetime."""
+    try:
+        return datetime.fromisoformat(value)
+    except Exception:
+        return None
+
+
+@export_bp.route('/messages', methods=['GET'])
+def export_messages():
+    """Download messages filtered by query parameters as a JSON file."""
+    channel = request.args.get('channel')
+    author = request.args.get('author')
+    start_str = request.args.get('start')
+    end_str = request.args.get('end')
+    limit = int(request.args.get('limit', '1000'))
+
+    start = parse_date(start_str) if start_str else None
+    end = parse_date(end_str) if end_str else None
+
+    messages = get_messages(channel, author, start, end, limit)
+
+    buffer = io.BytesIO()
+    buffer.write(json.dumps(messages, indent=2).encode('utf-8'))
+    buffer.seek(0)
+
+    filename = f"messages_{datetime.utcnow().strftime('%Y%m%d_%H%M%S')}.json"
+    return send_file(
+        buffer,
+        as_attachment=True,
+        download_name=filename,
+        mimetype='application/json'
+    )
+
+
+@export_bp.route('/messages.json', methods=['GET'])
+def export_messages_json():
+    """Return messages as JSON without download headers."""
+    channel = request.args.get('channel')
+    author = request.args.get('author')
+    start_str = request.args.get('start')
+    end_str = request.args.get('end')
+    limit = int(request.args.get('limit', '1000'))
+
+    start = parse_date(start_str) if start_str else None
+    end = parse_date(end_str) if end_str else None
+
+    messages = get_messages(channel, author, start, end, limit)
+    return jsonify({'count': len(messages), 'messages': messages})

--- a/features/export/cli.py
+++ b/features/export/cli.py
@@ -1,0 +1,38 @@
+"""Simple CLI for exporting messages."""
+import argparse
+import json
+from datetime import datetime
+
+from .service import get_messages
+
+
+def parse_date(text: str) -> datetime | None:
+    try:
+        return datetime.fromisoformat(text)
+    except Exception:
+        return None
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Export Discord messages to JSON")
+    parser.add_argument('--channel', help='Channel ID')
+    parser.add_argument('--author', help='Author ID')
+    parser.add_argument('--start', help='Start datetime (ISO format)')
+    parser.add_argument('--end', help='End datetime (ISO format)')
+    parser.add_argument('--limit', type=int, default=1000, help='Max messages')
+    parser.add_argument('outfile', help='Output file path')
+    args = parser.parse_args()
+
+    start = parse_date(args.start) if args.start else None
+    end = parse_date(args.end) if args.end else None
+
+    messages = get_messages(args.channel, args.author, start, end, args.limit)
+
+    with open(args.outfile, 'w', encoding='utf-8') as f:
+        json.dump(messages, f, indent=2)
+
+    print(f"Exported {len(messages)} messages to {args.outfile}")
+
+
+if __name__ == '__main__':
+    main()

--- a/features/export/dashboard.py
+++ b/features/export/dashboard.py
@@ -1,0 +1,17 @@
+"""Export Dashboard Blueprint
+
+Provides a simple interface to download messages using the export API.
+"""
+from flask import Blueprint, render_template
+
+export_dashboard_bp = Blueprint(
+    'export_dashboard', __name__,
+    template_folder='templates',
+    url_prefix='/dashboard/export'
+)
+
+
+@export_dashboard_bp.route('/')
+def overview():
+    """Render the export interface."""
+    return render_template('export/overview.html')

--- a/features/export/service.py
+++ b/features/export/service.py
@@ -1,0 +1,36 @@
+import logging
+from datetime import datetime
+from typing import List, Optional, Dict
+
+from common.db import db
+from features.ingestion.models import DiscordMessageModel
+
+logger = logging.getLogger(__name__)
+
+
+def get_messages(
+    channel_id: Optional[str] = None,
+    author_id: Optional[str] = None,
+    start: Optional[datetime] = None,
+    end: Optional[datetime] = None,
+    limit: int = 1000,
+) -> List[Dict[str, any]]:
+    """Retrieve messages filtered by channel, author, and date range."""
+    try:
+        query = db.session.query(DiscordMessageModel)
+        if channel_id:
+            query = query.filter(DiscordMessageModel.channel_id == str(channel_id))
+        if author_id:
+            query = query.filter(DiscordMessageModel.author_id == str(author_id))
+        if start:
+            query = query.filter(DiscordMessageModel.timestamp >= start)
+        if end:
+            query = query.filter(DiscordMessageModel.timestamp <= end)
+        query = query.order_by(DiscordMessageModel.timestamp.asc())
+        if limit:
+            query = query.limit(limit)
+        messages = query.all()
+        return [m.to_dict() for m in messages]
+    except Exception as e:
+        logger.error(f"Error exporting messages: {e}")
+        return []

--- a/features/export/templates/export/overview.html
+++ b/features/export/templates/export/overview.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Export Messages</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/css/bootstrap.min.css" rel="stylesheet">
+</head>
+<body>
+<div class="container mt-4">
+    <h1 class="mb-4">Export Messages</h1>
+    <form class="row g-3" method="get" action="/api/export/messages">
+        <div class="col-md-4">
+            <label for="channel" class="form-label">Channel ID</label>
+            <input type="text" class="form-control" id="channel" name="channel">
+        </div>
+        <div class="col-md-4">
+            <label for="author" class="form-label">Author ID</label>
+            <input type="text" class="form-control" id="author" name="author">
+        </div>
+        <div class="col-md-4">
+            <label for="limit" class="form-label">Limit</label>
+            <input type="number" class="form-control" id="limit" name="limit" value="1000">
+        </div>
+        <div class="col-md-6">
+            <label for="start" class="form-label">Start Date</label>
+            <input type="datetime-local" class="form-control" id="start" name="start">
+        </div>
+        <div class="col-md-6">
+            <label for="end" class="form-label">End Date</label>
+            <input type="datetime-local" class="form-control" id="end" name="end">
+        </div>
+        <div class="col-12">
+            <button type="submit" class="btn btn-primary">Download JSON</button>
+        </div>
+    </form>
+</div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- implement `features/export` slice with API, service, dashboard and CLI
- register export blueprints
- add Export button on dashboard

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pytz')*

------
https://chatgpt.com/codex/tasks/task_e_6866d6b9fb6483228e572063ee01c87e