### PR TITLE
Remove hard-coded ingestion service import

### DIFF
--- a/app.py
+++ b/app.py
@@ -110,12 +110,18 @@ async def start_unified_async_services(app):
 
             # Build your vertical slices
             try:
-                from features.ingestion.service import IngestionService
+                from common.plugin_loader import discover_class
                 from features.discord_channels.channel_manager import ChannelManager
                 from common.events.publisher import publish_event
                 from common.db import db
 
-                # Ingestion slice
+                # Ingestion slice via plugin discovery
+                IngestionService = discover_class(
+                    "IngestionService", ["features.ingestion.service"]
+                )
+                if not IngestionService:
+                    logging.error("IngestionService plugin not found")
+                    return
                 ingestion_svc = IngestionService()
 
                 # Channel slice
@@ -184,9 +190,15 @@ def initialize_async_services(app):
                 logging.info("Creating Discord bot services...")
                 
                 # Create services
-                from features.ingestion.service import IngestionService
+                from common.plugin_loader import discover_class
                 from features.discord_channels.channel_manager import ChannelManager
                 
+                IngestionService = discover_class(
+                    "IngestionService", ["features.ingestion.service"]
+                )
+                if not IngestionService:
+                    logging.error("IngestionService plugin not found")
+                    return
                 ingestion_svc = IngestionService()
                 channel_svc = ChannelManager()
                 logging.info("Discord bot services created successfully")

--- a/common/plugin_loader.py
+++ b/common/plugin_loader.py
@@ -1,0 +1,28 @@
+import importlib
+import logging
+from typing import List, Optional, Type
+
+logger = logging.getLogger(__name__)
+
+
+def discover_class(class_name: str, module_paths: List[str]) -> Optional[Type]:
+    """Dynamically discover a class from a list of module paths.
+
+    Args:
+        class_name: Name of the class to locate.
+        module_paths: Modules to search for the class.
+
+    Returns:
+        The class object if found, otherwise None.
+    """
+    for module_path in module_paths:
+        try:
+            module = importlib.import_module(module_path)
+            if hasattr(module, class_name):
+                return getattr(module, class_name)
+        except ImportError as e:
+            logger.debug("Plugin module %s not found: %s", module_path, e)
+        except Exception as e:
+            logger.warning("Error loading plugin %s: %s", module_path, e)
+    logger.warning("%s not found in plugins: %s", class_name, module_paths)
+    return None


### PR DESCRIPTION
## Summary
- add `common/plugin_loader.py` for plugin lookup
- refactor `app.py` to load `IngestionService` via plugin discovery

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pytz')*

------
https://chatgpt.com/codex/tasks/task_e_6866d6c753a88322840fdcf8c5a82ad1