### PR TITLE
Add README files for all feature slices

### DIFF
--- a/features/account/README.md
+++ b/features/account/README.md
@@ -1,0 +1,16 @@
+# Account Slice
+
+This slice manages user account information and related API endpoints.
+
+### Submodules:
+- `api_routes.py` – HTTP routes for account actions
+- `info.py` – Data retrieval and account models
+- `service.py` – Business logic for account management
+
+### Interfaces:
+- Exposes `/account` API routes
+- Used by other slices to fetch account details
+
+### TODO:
+- Persist account preferences
+- Add unit tests

--- a/features/alpaca/README.md
+++ b/features/alpaca/README.md
@@ -1,0 +1,16 @@
+# Alpaca Slice
+
+This slice integrates with the Alpaca brokerage API for trading operations.
+
+### Submodules:
+- `client.py` – Alpaca API client wrapper
+- `order_requests.py` – Helpers for order submission
+- `websocket_service.py` – Streaming updates and events
+
+### Interfaces:
+- Communicates with Alpaca REST and WebSocket endpoints
+- Provides trading functions to execution and strategy slices
+
+### TODO:
+- Improve error handling
+- Support additional account types

--- a/features/discord_channels/README.md
+++ b/features/discord_channels/README.md
@@ -1,0 +1,16 @@
+# Discord Channels Slice
+
+This slice manages Discord channel configurations and metadata.
+
+### Submodules:
+- `channel_manager.py` – Handles channel registration
+- `models.py` – Channel definitions
+- `service.py` – CRUD operations and lookups
+
+### Interfaces:
+- Provides APIs for channel management
+- Used by the Discord bot for channel mapping
+
+### TODO:
+- Add admin dashboard controls
+- Validate channel permissions

--- a/features/ingestion/README.md
+++ b/features/ingestion/README.md
@@ -1,0 +1,17 @@
+# Ingestion Slice
+
+This slice ingests Discord messages and stores them for further processing.
+
+### Submodules:
+- `fetcher.py` – Retrieves messages from Discord
+- `processor.py` – Normalizes and routes messages
+- `store.py` – Persistence layer
+- `validator.py` – Schema validation
+
+### Interfaces:
+- Listens to Discord events
+- Publishes `message.stored`
+
+### TODO:
+- Optimize message batching
+- Expand validation rules

--- a/features/options/README.md
+++ b/features/options/README.md
@@ -1,0 +1,16 @@
+# Options Slice
+
+This slice handles option contract data and calculations.
+
+### Submodules:
+- `selector.py` – Contract selection utilities
+- `greeks_calculator.py` – Option Greeks computation
+- `service.py` – Pricing and chain retrieval
+
+### Interfaces:
+- Used by strategy and execution slices
+- Provides option metrics and filtering
+
+### TODO:
+- Integrate volatility surface data
+- Enhance risk assessments

--- a/features/parsing/README.md
+++ b/features/parsing/README.md
@@ -1,0 +1,16 @@
+# Parsing Slice
+
+This slice handles all logic for parsing A+ trade setups from Discord messages.
+
+### Submodules:
+- `aplus_parser.py` – Logic specific to A+ format
+- `parser.py` – Core parsing utilities
+- `store.py` – Persistence for parsed setups
+
+### Interfaces:
+- Listens to `message.stored`
+- Publishes `setup.parsed`
+
+### TODO:
+- Refactor shared logic to `common/parsing`
+- Add more LLM parsing strategies

--- a/features/setups/README.md
+++ b/features/setups/README.md
@@ -1,0 +1,16 @@
+# Setups Slice
+
+This slice persists parsed trading setups and exposes them via API.
+
+### Submodules:
+- `api.py` – HTTP endpoints for setup data
+- `models.py` – Database models
+- `service.py` – Logic for creating and querying setups
+
+### Interfaces:
+- Publishes `setup.created`
+- Consumed by dashboard and strategy slices
+
+### TODO:
+- Add pagination to APIs
+- Implement cleanup of stale setups


### PR DESCRIPTION
## Summary
- add README for account, alpaca, discord_channels, ingestion, options, parsing and setups slices

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pytz')*

------
https://chatgpt.com/codex/tasks/task_e_6866d6d878088322b6acca318386dfa6